### PR TITLE
test: refine home page logo selector

### DIFF
--- a/e2e/home-page.spec.ts
+++ b/e2e/home-page.spec.ts
@@ -24,7 +24,9 @@ test.describe('Home Page', () => {
     await page.goto('/');
 
     // Check main heading and branding
-    await expect(page.getByText('easyloops')).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /easyloops Logo/i })
+    ).toBeVisible();
     await expect(page.getByText('Master Programming')).toBeVisible();
     // Target the specific heading that contains "One Problem at a Time"
     await expect(


### PR DESCRIPTION
## Summary
- use role-based selector to target the Easyloops header logo
- keep checks for "Master Programming" and "One Problem at a Time" headings

## Testing
- `npx playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npx playwright test e2e/home-page.spec.ts --project=chromium` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1179/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68a731d8ea40832186acd664f63b0a23