### PR TITLE
test: fix submission flow header selector

### DIFF
--- a/e2e/submission-flow.spec.ts
+++ b/e2e/submission-flow.spec.ts
@@ -6,8 +6,8 @@ test.describe('Submission Flow E2E', () => {
     // Navigate to a specific question page where the code editor is available
     await page.goto('/questions/01-variable-declaration');
 
-    // Wait for the app to load - look for the easyloops header
-    await page.waitForSelector('h1:has-text("easyloops")');
+    // Wait for the app to load - look for the header link back to home
+    await page.waitForSelector('header a[href="/"]');
 
     // Clear all persistent state after page loads
     await clearPersistentState(page);


### PR DESCRIPTION
## Summary
- fix submission flow e2e test selector to wait for site header link

## Testing
- `npx playwright test e2e/submission-flow.spec.ts --project=chromium` *(fails: Test was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a731da8a4c8321b80a94e0f5072a53