### PR TITLE
test: fix home page logo selector

### DIFF
--- a/e2e/home-page.spec.ts
+++ b/e2e/home-page.spec.ts
@@ -24,7 +24,11 @@ test.describe('Home Page', () => {
     await page.goto('/');
 
     // Check main heading and branding
-    await expect(page.getByText('easyloops')).toBeVisible();
+    await expect(
+      page
+        .getByRole('link')
+        .filter({ has: page.locator('svg[aria-label="easyloops Logo"]') })
+    ).toBeVisible();
     await expect(page.getByText('Master Programming')).toBeVisible();
     // Target the specific heading that contains "One Problem at a Time"
     await expect(


### PR DESCRIPTION
## Summary
- update home page spec to target link containing logo SVG

## Testing
- `npx playwright test e2e/home-page.spec.ts --project=chromium` *(fails: 8 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a88dc5d56c8321a6796e9726d8e8e9